### PR TITLE
Add move configuration functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,44 @@
 # Helm 2to3 Plugin
 
-This is a Helm plugin which migrates Helm v2 releases in-place to Helm v3
+This is a Helm plugin which migrates Helm v2 configuration and releases in-place to Helm v3
 
 ## Usage
 
-migrate Helm v2 releases in-place to Helm v3
+### Migrate Helm v2 configuration
+
+Migrate Helm v2 configuration in-place to Helm v3:
+
+```console
+$ helm 2to3 move config [flags]
+```
+
+Flags:
 
 ```
+  -h, --help     help for move
+```
+
+For migration it uses default Helm v2 home and v3 config  and data folders.
+To override those folders you need to set environment variables `HELM_V2_HOME, `HELM_V3_CONFIG` and `HELM_V3_DATA`:
+
+```console
+$ export HELM_V2_HOME=$PWD/.helm2
+$ export HELM_V3_CONFIG=$PWD/.helm3
+$ export HELM_V3_DATA=$PWD/.helm3
+$ helm 2to3 move config
+```
+
+The `move config` will create the Helm v3 config and data folders if they don't exist, and will override the `repositories.yaml` file if it does exist.
+
+### Migrate Helm v2 releases
+
+Migrate Helm v2 releases in-place to Helm v3
+
+```console
 $ helm 2to3 convert [flags] RELEASE
 ```
 
-### Flags:
+Flags:
 
 ```
       --dry-run            simulate a convert
@@ -18,7 +46,7 @@ $ helm 2to3 convert [flags] RELEASE
       --keep-v2-releases   v2 releases are retained after migration. By default, the v2 releases are removed
   -l, --label string       label to select tiller resources by (default "OWNER=TILLER")
   -s, --release-storage string   v2 release storage type/object. It can be 'configmaps' or 'secrets'. This is only used with the 'tiller-out-cluster' flag (default "configmaps")
-  -t, --tiller-ns string   namespace of Tiller (default "kube-system")A
+  -t, --tiller-ns string   namespace of Tiller (default "kube-system")
       --tiller-out-cluster       when  Tiller is not running in the cluster e.g. Tillerless
 ```
 
@@ -32,7 +60,7 @@ If you would like to handle the build yourself, this is the recommended way to d
 
 You must first have [Go](http://golang.org) installed , and then you run:
 
-```
+```console
 $ git clone git@github.com:hickeyma/helm-2to3.git
 $ cd helm-2to3
 $ make

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -71,7 +71,7 @@ func run(cmd *cobra.Command, args []string) error {
 	return Convert(releaseName)
 }
 
-// Convert coonverts helm 2 release into Hlem 3 relesae. It maps the Helm v2 release versions
+// Convert converts helm 2 release into Helm 3 release. It maps the Helm v2 release versions
 // of the release into Helm v3 equivalent and stores the release versions. The underlying  Kubernetes resources
 // are untouched. Note: The namespaces of each release version need to exist in the Kubernetes  cluster.
 // The Helm 2 release is deleted by default, unless the '--keepv2Releases' flag is set.

--- a/cmd/move_config.go
+++ b/cmd/move_config.go
@@ -1,0 +1,219 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+
+	"helm.sh/helm/pkg/helmpath"
+)
+
+func newMoveConfigCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "move config",
+		Short: "migrate Helm v2 configuration in-place to Helm v3",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("config argument has to be specified")
+			}
+			return nil
+		},
+		RunE: runMove,
+	}
+
+	return cmd
+}
+
+func runMove(cmd *cobra.Command, args []string) error {
+	moveArgName := args[0]
+
+	if moveArgName != "config" {
+		return errors.New("config argument has to be specified")
+	}
+
+	return move()
+}
+
+func v2HomeDir() string {
+	if homeDir, exists := os.LookupEnv("HELM_V2_HOME"); exists {
+		return homeDir
+	}
+
+	homeDir, _ := homedir.Dir()
+	defaultDir := homeDir + "/.helm"
+	fmt.Printf("[Helm 2] Home directory: %s\n", defaultDir)
+	return defaultDir
+}
+
+func v3ConfigDir() string {
+	if homeDir, exists := os.LookupEnv("HELM_V3_CONFIG"); exists {
+		return homeDir
+	}
+
+	defaultDir := helmpath.ConfigPath()
+	fmt.Printf("[Helm 3] Config directory: %s\n", defaultDir)
+	return defaultDir
+}
+
+func v3DataDir() string {
+	if homeDir, exists := os.LookupEnv("HELM_V3_DATA"); exists {
+		return homeDir
+	}
+
+	defaultDir := helmpath.DataPath()
+	fmt.Printf("[Helm 3] Data directory: %s\n", defaultDir)
+	return defaultDir
+}
+
+func move() error {
+	v2HomeDir := v2HomeDir()
+	v3ConfigDir := v3ConfigDir()
+	v3DataDir := v3DataDir()
+
+	// Create Helm v3 config directory if needed
+	fmt.Printf("i[Helm 3] Create config folder \"%s\" .\n", v3ConfigDir)
+	err := ensureDir(v3ConfigDir)
+	if err != nil {
+		return fmt.Errorf("[Helm 3] Failed to create config folder \"%s\" due to the following error: %s", v3ConfigDir, err)
+	}
+	fmt.Printf("[Helm 3] Config folder \"%s\" created.\n", v3ConfigDir)
+
+	// Move repo config
+	v2RepoConfig := v2HomeDir + "/repository/repositories.yaml"
+	v3RepoConfig := v3ConfigDir + "/repositories.yaml"
+	fmt.Printf("[Helm 2] repositories file \"%s\" will copy to [Helm 3] config folder \"%s\" .\n", v2RepoConfig, v3RepoConfig)
+	err = copyFile(v2RepoConfig, v3RepoConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to copy [Helm 2] repository file \"%s\" due to the following error: %s", v2RepoConfig, err)
+	}
+	fmt.Printf("[Helm 2] repositories file \"%s\" copied successfully to [Helm 3] config folder \"%s\" .\n", v2RepoConfig, v3RepoConfig)
+
+	// Bot moving local repo as it is no longer5 supported in v3: v2HomeDir/repository/local
+
+	// Not moving the cache as it is safer to recreate when needed
+	// v2HomeDir/cache and v2HomeDir/repository/cache
+
+	// Create Helm v3 data directory if needed
+	fmt.Printf("[Helm 3] Create data folder \"%s\" .\n", v3DataDir)
+	err = ensureDir(v3DataDir)
+	if err != nil {
+		return fmt.Errorf("[Helm 3] Failed to create data folder \"%s\" due to the following error: %s", v3DataDir, err)
+	}
+	fmt.Printf("[Helm 3] data folder \"%s\" created.\n", v3DataDir)
+
+	// Move plugins
+	v2Plugins := v2HomeDir + "/plugins"
+	v3Plugins := v3DataDir + "/plugins"
+	fmt.Printf("[Helm 2] plugins \"%s\" will copy to [Helm 3] data folder \"%s\" .\n", v2Plugins, v3Plugins)
+	err = copyDir(v2Plugins, v3Plugins)
+	if err != nil {
+		return fmt.Errorf("Failed to copy [Helm 2] plugins directory \"%s\" due to the following error: %s", v2Plugins, err)
+	}
+	fmt.Printf("[Helm 2] plugins \"%s\" copied successfully to [Helm 3] data folder \"%s\" .\n", v2Plugins, v3Plugins)
+
+	// Move starters
+	v2Starters := v2HomeDir + "/starters"
+	v3Starters := v3DataDir + "/starters"
+	fmt.Printf("[Helm 2] starters \"%s\" will copy to [Helm 3] data folder \"%s\" .\n", v2Starters, v3Starters)
+	err = copyDir(v2Starters, v3Starters)
+	if err != nil {
+		return fmt.Errorf("Failed to copy [Helm 2] starters \"%s\" due to the following error: %s", v2Starters, err)
+	}
+	fmt.Printf("[Helm 2] starters \"%s\" copied successfully to [Helm 3] data folder \"%s\" .\n", v2Starters, v3Starters)
+
+	return nil
+}
+
+func copyFile(srcFileName, destFileName string) error {
+	input, err := ioutil.ReadFile(srcFileName)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(destFileName, input, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyDir(srcDirName, destDirName string) error {
+	err := ensureDir(destDirName)
+	if err != nil {
+		return fmt.Errorf("Failed to create folder \"%s\" due to the following error: %s", destDirName, err)
+	}
+
+	directory, _ := os.Open(srcDirName)
+	objects, err := directory.Readdir(-1)
+	for _, obj := range objects {
+		srcFileName := srcDirName + "/" + obj.Name()
+		destFileName := destDirName + "/" + obj.Name()
+		if obj.IsDir() {
+			// create sub-directories - recursively
+			err = copyDir(srcFileName, destFileName)
+			if err != nil {
+				return fmt.Errorf("Failed to copy folder \"%s\" to folder \"%s\" due to the following error: %s", srcFileName, destFileName, err)
+			}
+		} else {
+			fileInfo, err := os.Lstat(srcFileName)
+			if err != nil {
+				return fmt.Errorf("Failed to check file \"%s\" stats  due to the following error: %s", srcFileName, err)
+			}
+			if fileInfo.Mode()&os.ModeSymlink != 0 {
+				err = copySymLink(obj, srcDirName, destDirName)
+				if err != nil {
+					return fmt.Errorf("Failed to create symlink for  \"%s\" due to the following error: %s", obj.Name(), err)
+				}
+			} else {
+				err = copyFile(srcFileName, destFileName)
+				if err != nil {
+					return fmt.Errorf("Failed to copy file  \"%s\" to \"%s\" due to the following error: %s", srcFileName, destFileName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func ensureDir(dirName string) error {
+	err := os.MkdirAll(dirName, os.ModePerm)
+	if err != nil || !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+func copySymLink(fileInfo os.FileInfo, srcDirName, destDirName string) error {
+	originFileName, err := os.Readlink(srcDirName + "/" + fileInfo.Name())
+	if err != nil {
+		return err
+	}
+	newSymLinkName := destDirName + "/" + fileInfo.Name()
+	err = os.Symlink(originFileName, newSymLinkName)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,8 @@ import (
 func NewRootCmd(out io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "2to3",
-		Short:        "migrate Helm v2 releases in-place to Helm v3",
-		Long:         "migrate Helm v2 releases in-place to Helm v3",
+		Short:        "Migrate Helm v2 configuration and releases in-place to Helm v3",
+		Long:         "Migrate Helm v2 configuration and releases in-place to Helm v3",
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -42,6 +42,7 @@ func NewRootCmd(out io.Writer, args []string) *cobra.Command {
 
 	cmd.AddCommand(
 		newConvertCmd(out),
+		newMoveConfigCmd(out),
 	)
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,12 @@ require (
 	github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v0.0.3
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
-	helm.sh/helm v3.0.0-beta.2+incompatible
+	helm.sh/helm v3.0.0-beta.3+incompatible
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cli-runtime v0.0.0
 	k8s.io/helm v2.14.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/miekg/dns v0.0.0-20181005163659-0d29b283ac0f h1:wVzAD6PG9MIDNQMZ6zc2Y
 github.com/miekg/dns v0.0.0-20181005163659-0d29b283ac0f/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v0.0.0-20151009155749-1b4ae6fb4e77/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -527,6 +529,8 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 helm.sh/helm v3.0.0-beta.2+incompatible h1:8J15Tewre8l5i+dEpkvHDHqdaleXgpykAGzIPs6cp0k=
 helm.sh/helm v3.0.0-beta.2+incompatible/go.mod h1:0Xbc6ErzwWH9qC55X1+hE3ZwhM3atbhCm/NbFZw5i+4=
+helm.sh/helm v3.0.0-beta.3+incompatible h1:/U/yApDO3EL8dUqTfK+PYLLmAv22HzIhXUYPEzZSSNk=
+helm.sh/helm v3.0.0-beta.3+incompatible/go.mod h1:0Xbc6ErzwWH9qC55X1+hE3ZwhM3atbhCm/NbFZw5i+4=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711 h1:BblVYz/wE5WtBsD/Gvu54KyBUTJMflolzc5I2DTvh50=

--- a/pkg/v2/release.go
+++ b/pkg/v2/release.go
@@ -38,7 +38,7 @@ type DeleteOptions struct {
 	Versions []int32
 }
 
-// GetReleaseVersions returns all rrelease versions from Helm v2 storage for a specified release
+// GetReleaseVersions returns all release versions from Helm v2 storage for a specified release
 func GetReleaseVersions(retOpts RetrieveOptions) ([]*rls.Release, error) {
 	releases, err := getReleases(retOpts)
 	if err != nil {

--- a/pkg/v3/release.go
+++ b/pkg/v3/release.go
@@ -86,7 +86,7 @@ func CreateRelease(v2Rel *v2rls.Release) (*release.Release, error) {
 	}, nil
 }
 
-// StoreRelease stores a release objevct in Helm v3 storage
+// StoreRelease stores a release object in Helm v3 storage
 func StoreRelease(rel *release.Release) error {
 	cfg, err := GetActionConfig(rel.Namespace)
 	if err != nil {
@@ -253,7 +253,6 @@ func mapHookEvents(v2HookEvents []v2rls.Hook_Event) ([]release.HookEvent, error)
 		event := release.HookEvent(strings.ToLower(v2EventStr))
 		hookEvents = append(hookEvents, event)
 	}
-	//TODO: hook.LastRun =
 	return hookEvents, nil
 }
 


### PR DESCRIPTION
Add functionality to move Helm v2 configuration to Helm v3. 

This covers:
- Repository file
- Plugins
- Starters

Note: Based off https://github.com/hickeyma/helm-2to3/pull/20 with following changes:
- Added data configuration like plugins, starters etc.
- Extracted from code changes for builds

Closes #12 
Closes #17 